### PR TITLE
Ensure driverName is set by using org.wildfly.swarm.datasources.JdbcDriver

### DIFF
--- a/datasource-subsystem/src/main/java/org/wildfly/swarm/examples/ds/subsystem/Main.java
+++ b/datasource-subsystem/src/main/java/org/wildfly/swarm/examples/ds/subsystem/Main.java
@@ -2,9 +2,8 @@ package org.wildfly.swarm.examples.ds.subsystem;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.wildfly.swarm.config.datasources.DataSource;
-import org.wildfly.swarm.config.datasources.JdbcDriver;
+import org.wildfly.swarm.datasources.JdbcDriver;
 import org.wildfly.swarm.container.Container;
-import org.wildfly.swarm.container.Fraction;
 import org.wildfly.swarm.datasources.DatasourcesFraction;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 


### PR DESCRIPTION
While trying out the datasources example I got an exception that the driver name wasn't set - I saw there was a org.wildfly.swarm.datasources.JdbcDriver that does set the name (as opposed to org.wildfly.swarm.config.datasources.JdbcDriver which was used). Not sure if it's the correct way to go but it works ;)

Was trying this against HEAD of Swarm Alpha5.