### PR TITLE
Add a JAX-WS example

### DIFF
--- a/jaxws/README.md
+++ b/jaxws/README.md
@@ -1,0 +1,105 @@
+# JAX-WS .war Example
+
+This example takes a normal JAX-WS build, and wraps it into
+a `-swarm` runnable jar.
+
+It is originally from [wildfly-quickstart helloworld-ws](https://github.com/wildfly/quickstart/tree/10.x/helloworld-ws).
+
+> Please raise any issues found with this example in this repo:
+> https://github.com/wildfly-swarm/wildfly-swarm-examples
+>
+> Issues related to WildFly Swarm core should be raised in the main repo:
+> https://github.com/wildfly-swarm/wildfly-swarm/issues
+
+## Project `pom.xml`
+
+This project is a traditional JAX-RS project, with maven packaging
+of `war` in the `pom.xml`
+
+``` xml
+<packaging>war</packaging>
+```
+
+The project adds a `<plugin>` to configure `wildfly-swarm-plugin` to
+create the runnable `.jar`.
+
+``` xml
+<plugin>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-plugin</artifactId>
+  <version>${version.wildfly-swarm}</version>
+  <executions>
+    <execution>
+      <goals>
+        <goal>package</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```
+
+To define the needed parts of WildFly Swarm, a dependency is added
+
+``` xml
+<dependency>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-webservices</artifactId>
+    <version>${version.wildfly-swarm}</version>
+</dependency>
+```
+
+This dependency provides the JAX-WS APIs to your application, so the
+project does *not* need to specify those.
+
+## Run
+
+* mvn package && java -jar ./target/wildfly-swarm-example-jaxws-swarm.jar
+* mvn wildfly-swarm:run
+* From your IDE, run class `org.wildfly.swarm.Swarm`
+
+## Use
+
+Since WildFly Swarm apps tend to support one deployment per executable, it
+automatically adds a `jboss-web.xml` to the deployment if it doesn't already
+exist.  This is used to bind the deployment to the root of the web-server,
+instead of using the `.war`'s own name as the application context.
+
+```
+http://localhost:8080/
+```
+
+The above resource displays the `wsdl` link.
+ 
+## Run the Client Tests using Arquillian
+
+This example has a test case to access the webservice from a client with Arquillian.
+
+``` sh
+$ mvn clean test
+...
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.wildfly.swarm.examples.jaxws.ClientArqTest
+...
+2015-11-13 01:51:10,702 INFO  [org.jboss.ws.cxf.metadata] (MSC service thread 1-4) JBWS024061: Adding service endpoint metadata: id=org.wildfly.swarm.examples.jaxws.HelloWorldServiceImpl
+ address=http://localhost:8080/HelloWorldService
+ implementor=org.wildfly.swarm.examples.jaxws.HelloWorldServiceImpl
+ serviceName={http://wildfly-swarm.io/HelloWorld}HelloWorldService
+ portName={http://wildfly-swarm.io/HelloWorld}HelloWorld
+ annotationWsdlLocation=null
+ wsdlLocationOverride=null
+ mtomEnabled=false
+...
+[Client] Requesting the WebService to say Hello.
+[WebService] Hello World!
+[Client] Requesting the WebService to say Hello to John.
+[WebService] Hello John!
+[Client] Requesting the WebService to say Hello to John, Mary and Mark.
+[WebService] Hello John, Mary & Mark!
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 44.405 sec
+
+Results :
+
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
+```

--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm.examples</groupId>
+    <artifactId>wildfly-swarm-examples-parent</artifactId>
+    <version>1.0.0.Alpha6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>wildfly-swarm-example-jaxws</artifactId>
+
+  <name>WildFly Swarm Examples: JAX-WS</name>
+  <description>WildFly Swarm Examples: JAX-WS</description>
+
+  <packaging>war</packaging>
+
+  <properties>
+    <version.org.arquillian>1.1.8.Final</version.org.arquillian>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <packagingExcludes>WEB-INF/lib/wildfly-swarm-*.jar</packagingExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-undertow</artifactId>
+      <version>${version.wildfly-swarm}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-security</artifactId>
+      <version>${version.wildfly-swarm}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-webservices</artifactId>
+      <version>${version.wildfly-swarm}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-arquillian</artifactId>
+      <version>${version.wildfly-swarm}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <version>${version.org.arquillian}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/HelloWorldService.java
+++ b/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/HelloWorldService.java
@@ -1,0 +1,45 @@
+package org.wildfly.swarm.examples.jaxws;
+
+import java.util.List;
+
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+
+/**
+ * A simple example of how to setup a JAX-WS Web Service. It can say hello to everyone or to someone in particular.
+ *
+ * @author lnewson@redhat.com
+ * @author Yoshimasa Tanabe
+ *
+ */
+
+@WebService(targetNamespace = "http://wildfly-swarm.io/HelloWorld")
+public interface HelloWorldService {
+
+    /**
+     * Say hello as a response
+     *
+     * @return A simple hello world message
+     */
+    @WebMethod
+    public String sayHello();
+
+    /**
+     * Say hello to someone precisely
+     *
+     * @param name The name of the person to say hello to
+     * @return the number of current bookings
+     */
+    @WebMethod
+    public String sayHelloToName(String name);
+
+    /**
+     * Say hello to a list of people
+     *
+     * @param names The list of names to say hello to
+     * @return the number of current bookings
+     */
+    @WebMethod
+    public String sayHelloToNames(List<String> names);
+
+}

--- a/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/HelloWorldServiceImpl.java
+++ b/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/HelloWorldServiceImpl.java
@@ -1,0 +1,79 @@
+package org.wildfly.swarm.examples.jaxws;
+
+/**
+ * @author Yoshimasa Tanabe
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.jws.WebService;
+
+/**
+ * The implementation of the HelloWorld JAX-WS Web Service.
+ *
+ * @author lnewson@redhat.com
+ * @author Yoshimasa Tanabe
+ */
+@WebService(serviceName = "HelloWorldService", portName = "HelloWorld", name = "HelloWorld", endpointInterface = "org.wildfly.swarm.examples.jaxws.HelloWorldService",
+        targetNamespace = "http://wildfly-swarm.io/HelloWorld")
+public class HelloWorldServiceImpl implements HelloWorldService {
+
+    @Override
+    public String sayHello() {
+        return "Hello World!";
+    }
+
+    @Override
+    public String sayHelloToName(final String name) {
+
+        /* Create a list with just the one value */
+        final List<String> names = new ArrayList<>();
+        names.add(name);
+
+        return sayHelloToNames(names);
+    }
+
+    @Override
+    public String sayHelloToNames(final List<String> names) {
+        return "Hello " + createNameListString(names);
+    }
+
+    /**
+     * Creates a list of names separated by commas or an and symbol if its the last separation. This is then used to say hello to
+     * the list of names.
+     *
+     * i.e. if the input was {John, Mary, Luke} the output would be John, Mary & Luke
+     *
+     * @param names A list of names
+     * @return The list of names separated as described above.
+     */
+    private String createNameListString(final List<String> names) {
+
+        /*
+         * If the list is null or empty then assume the call was anonymous.
+         */
+        if (names == null || names.isEmpty()) {
+            return "Anonymous!";
+        }
+
+        final StringBuilder nameBuilder = new StringBuilder();
+        for (int i = 0; i < names.size(); i++) {
+
+            /*
+             * Add the separator if its not the first string or the last separator since that should be an and (&) symbol.
+             */
+            if (i != 0 && i != names.size() - 1)
+                nameBuilder.append(", ");
+            else if (i != 0 && i == names.size() - 1)
+                nameBuilder.append(" & ");
+
+            nameBuilder.append(names.get(i));
+        }
+
+        nameBuilder.append("!");
+
+        return nameBuilder.toString();
+    }
+
+}

--- a/jaxws/src/main/webapp/index.html
+++ b/jaxws/src/main/webapp/index.html
@@ -1,0 +1,41 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<html>
+<head><title>jboss-helloworld-ws Quickstart with WildFly Swarm</title></head>
+
+<body>
+
+<h1>helloworld-ws Quickstart with WildFly Swarm</h1>
+
+<p>
+  The <i>helloworld-ws</i> quickstart demonstrates the use of <b>JAX-WS</b> in
+  Red Hat JBoss Enterprise Application Platform as a simple Hello World application.
+</p>
+
+<p>
+  There is no user interface for this quickstart. Instead, you can verify the
+  Web Service is running and deployed correctly by accessing the following URL:
+</p>
+
+<div style="margin-left: 1em;">
+  <a href="HelloWorldService?wsdl">HelloWorldService?wsdl</a>
+</div>
+<p>
+  This URL will display the WSDL definition for the deployed Web Service endpoint.
+</p>
+</body>
+
+</html>

--- a/jaxws/src/test/java/org/wildfly/swarm/examples/jaxws/Client.java
+++ b/jaxws/src/test/java/org/wildfly/swarm/examples/jaxws/Client.java
@@ -1,0 +1,68 @@
+package org.wildfly.swarm.examples.jaxws;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.Service;
+
+/**
+ * A Client stub to the HelloWorld JAX-WS Web Service.
+ *
+ * @author lnewson@redhat.com
+ * @author Yoshimasa Tanabe
+ *
+ */
+public class Client implements HelloWorldService {
+
+    private HelloWorldService helloWorldService;
+
+    /**
+     * Default constructor
+     *
+     * @param url The URL to the Hello World WSDL endpoint.
+     */
+    public Client(final URL wsdlUrl) {
+        QName serviceName = new QName("http://wildfly-swarm.io/HelloWorld", "HelloWorldService");
+
+        Service service = Service.create(wsdlUrl, serviceName);
+        helloWorldService = service.getPort(HelloWorldService.class);
+        assert (helloWorldService != null);
+    }
+
+    /**
+     * Default constructor
+     *
+     * @param url The URL to the Hello World WSDL endpoint.
+     * @throws MalformedURLException if the WSDL url is malformed.
+     */
+    public Client(final String url) throws MalformedURLException {
+        this(new URL(url));
+    }
+
+    /**
+     * Gets the Web Service to say hello
+     */
+    @Override
+    public String sayHello() {
+        return helloWorldService.sayHello();
+    }
+
+    /**
+     * Gets the Web Service to say hello to someone
+     */
+    @Override
+    public String sayHelloToName(final String name) {
+        return helloWorldService.sayHelloToName(name);
+    }
+
+    /**
+     * Gets the Web Service to say hello to a group of people
+     */
+    @Override
+    public String sayHelloToNames(final List<String> names) {
+        return helloWorldService.sayHelloToNames(names);
+    }
+
+}

--- a/jaxws/src/test/java/org/wildfly/swarm/examples/jaxws/ClientArqTest.java
+++ b/jaxws/src/test/java/org/wildfly/swarm/examples/jaxws/ClientArqTest.java
@@ -1,0 +1,95 @@
+package org.wildfly.swarm.examples.jaxws;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Simple set of tests for the HelloWorld Web Service to demonstrate accessing the web service using a client
+ *
+ * @author lnewson@redhat.com
+ * @author Yoshimasa Tanabe
+ *
+ */
+@RunWith(Arquillian.class)
+public class ClientArqTest {
+
+    /**
+     * The path of the WSDL endpoint in relation to the deployed web application.
+     */
+    private static final String WSDL_PATH = "HelloWorldService?wsdl";
+
+    @ArquillianResource
+    private URL deploymentUrl;
+
+    private HelloWorldService client;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackage(HelloWorldService.class.getPackage());
+    }
+
+    @Before
+    public void setup() {
+        try {
+            client = new Client(new URL(deploymentUrl, WSDL_PATH));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testHello() {
+        System.out.println("[Client] Requesting the WebService to say Hello.");
+
+        // Get a response from the WebService
+        final String response = client.sayHello();
+        assertEquals(response, "Hello World!");
+
+        System.out.println("[WebService] " + response);
+
+    }
+
+    @Test
+    public void testHelloName() {
+        System.out.println("[Client] Requesting the WebService to say Hello to John.");
+
+        // Get a response from the WebService
+        final String response = client.sayHelloToName("John");
+        assertEquals(response, "Hello John!");
+
+        System.out.println("[WebService] " + response);
+    }
+
+    @Test
+    public void testHelloNames() {
+        System.out.println("[Client] Requesting the WebService to say Hello to John, Mary and Mark.");
+
+        // Create the array of names for the WebService to say hello to.
+        final List<String> names = new ArrayList<>();
+        names.add("John");
+        names.add("Mary");
+        names.add("Mark");
+
+        // Get a response from the WebService
+        final String response = client.sayHelloToNames(names);
+        assertEquals(response, "Hello John, Mary & Mark!");
+
+        System.out.println("[WebService] " + response);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <module>jaxrs-cdi</module>
     <module>jaxrs-msc</module>
     <module>jaxrs-shrinkwrap</module>
+    <module>jaxws</module>
     <module>jpa-jaxrs-cdi</module>
     <module>jpa-jaxrs-cdi-shrinkwrap</module>
     <module>jpa-jaxrs-cdi-shrinkwrap2</module>


### PR DESCRIPTION
I add an arquillian test(run as client)  to this example like [the original example](https://github.com/wildfly/quickstart/tree/10.x/helloworld-ws).

On my environment, the test displays the following logs at first, so it takes time(about 1 min.)

```
Nov 13, 2015 2:20:50 AM org.jboss.shrinkwrap.resolver.impl.maven.logging.LogTransferListener transferFailed
WARNING: Failed downloading org/wildfly/swarm/wildfly-swarm-security/1.0.0.Alpha6-SNAPSHOT/maven-metadata.xml from http://repo1.maven.org/maven2/. Reason: 
org.eclipse.aether.transfer.MetadataNotFoundException: Could not find metadata org.wildfly.swarm:wildfly-swarm-security:1.0.0.Alpha6-SNAPSHOT/maven-metadata.xml in central (http://repo1.maven.org/maven2)
...
```

[full logs](https://gist.github.com/emag/3db1b6092206612a55f2)

If it's undesirable and reproduce anyware, I will remove the test and create a similar standalone ws-client. Please let me know. 

Thanks.