### PR TITLE
[SWARM-121] Enable clustering for messaging

### DIFF
--- a/messaging/messaging-clustering/pom.xml
+++ b/messaging/messaging-clustering/pom.xml
@@ -29,6 +29,10 @@
         <artifactId>wildfly-swarm-plugin</artifactId>
         <configuration>
           <mainClass>org.wildfly.swarm.examples.messaging.clustering.Main</mainClass>
+          <properties>
+            <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+            <swarm.bind.address>127.0.0.1</swarm.bind.address>
+          </properties>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
add swarm.bind.address=127.0.0.1 & java.net.preferIPv4Stack=true to
ensure that JGroups does not complain about binding to 0.0.0.0.
This error was preventing mvn verify to pass.

JIRA: https://issues.jboss.org/browse/SWARM-121