### PR TITLE
[SWARM-336], [SWARM-541] Fix gradle build

### DIFF
--- a/gradle/README.md
+++ b/gradle/README.md
@@ -10,7 +10,7 @@ Beginning of a Gradle plugin example.
 
 ##Run
 
-`java -jar ./build/libs/wildfly-swarm-example-gradle-swarm.jar`
+`java -jar ./build/libs/example-gradle-swarm.jar`
 
 
 ## Configuration

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  version = System.getProperty('swarmVersion') ?: '1.0.0.CR1-SNAPSHOT'
+  version = System.getProperty('swarmVersion') ?: '1.0.0.Final'
 
   repositories {
     mavenLocal()
@@ -28,6 +28,9 @@ swarm {
 repositories {
   mavenLocal()
   mavenCentral()
+  maven {
+    url 'https://maven.repository.redhat.com/nexus/content/repositories/thirdparty-releases/'
+  }
 }
 
 dependencyManagement {


### PR DESCRIPTION
Gradle build for gradle example fails because of missing version
and missing dependency. Usage refers to the wrong jar name.

Changes version in build.gradle file to 1.0.0.Final and adds redhat
maven repo for javax.el-impl.3.0.1-b08-jbossorg-1. README.md updated
to point to correct jar file name.