### PR TITLE
datasource-deployment: use try-with-resource

### DIFF
--- a/datasource/datasource-deployment/src/main/java/org/wildfly/swarm/examples/ds/deployment/MyResource.java
+++ b/datasource/datasource-deployment/src/main/java/org/wildfly/swarm/examples/ds/deployment/MyResource.java
@@ -22,11 +22,8 @@ public class MyResource {
     public String get() throws NamingException, SQLException {
         Context ctx = new InitialContext();
         DataSource ds = (DataSource) ctx.lookup("jboss/datasources/ExampleDS");
-        Connection conn = ds.getConnection();
-        try {
+        try (Connection conn = ds.getConnection()) {
             return "Howdy using connection: " + conn;
-        } finally {
-            conn.close();
         }
     }
 }


### PR DESCRIPTION
Utilize Java 7's try-with-resource syntax to remove boiler-plate code
from this example.