### PR TITLE
SWARM-806: JPA+JAX-RS+CDI+JTA examples have wrong assertions

### DIFF
--- a/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-shrinkwrap/src/it/java/org/wildfly/swarm/it/jpajaxrscdijta/JPAJAXRSCDIJTAApplicationIT.java
+++ b/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-shrinkwrap/src/it/java/org/wildfly/swarm/it/jpajaxrscdijta/JPAJAXRSCDIJTAApplicationIT.java
@@ -58,10 +58,10 @@ public class JPAJAXRSCDIJTAApplicationIT extends AbstractIntegrationTest {
         assertThat(browser.getPageSource()).contains("*** On purpose failure during removal to test Rollback ***");
 
         browser.navigate().to("http://localhost:8080/rollbackMsg");
-        assertThat(browser.getPageSource().contains("5"));
+        assertThat(browser.getPageSource()).contains("5");
 
         browser.navigate().to("http://localhost:8080/commitMsg");
-        assertThat(browser.getPageSource().contains("0"));
+        assertThat(browser.getPageSource()).contains("0");
 
 
         testAll();
@@ -81,9 +81,9 @@ public class JPAJAXRSCDIJTAApplicationIT extends AbstractIntegrationTest {
         }
         assertThat(browser.getPageSource()).contains("*** On purpose failure during removal to test Rollback ***");
         browser.navigate().to("http://localhost:8080/rollbackMsg");
-        assertThat(browser.getPageSource().contains("0"));
+        assertThat(browser.getPageSource()).contains("0");
         browser.navigate().to("http://localhost:8080/commitMsg");
-        assertThat(browser.getPageSource().contains("3"));
+        assertThat(browser.getPageSource()).contains("3");
         browser.navigate().to("http://localhost:8080/all");
         assertThat(browser.getPageSource()).doesNotContain("{\"id\":1,\"name\":\"Penny\"}");
         assertThat(browser.getPageSource()).doesNotContain("{\"id\":2,\"name\":\"Sheldon\"}");

--- a/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-shrinkwrap/src/main/java/org/wildfly/swarm/examples/jpajaxrscdijta/EmployeeResource.java
+++ b/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-shrinkwrap/src/main/java/org/wildfly/swarm/examples/jpajaxrscdijta/EmployeeResource.java
@@ -51,6 +51,7 @@ public class EmployeeResource {
 
     @GET
     @Path("rollbackMsg")
+    @Produces("text/plain")
     public int getRollBackMsg() {
 
         return service.getRollbackMsg().size();
@@ -58,6 +59,7 @@ public class EmployeeResource {
 
     @GET
     @Path("commitMsg")
+    @Produces("text/plain")
     public int getCommitMsg() {
 
         return service.getCommitMsg().size();

--- a/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-war/src/it/java/org/wildfly/swarm/it/jpajaxrscdijta/JPAJAXRSCDIJTAApplicationIT.java
+++ b/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-war/src/it/java/org/wildfly/swarm/it/jpajaxrscdijta/JPAJAXRSCDIJTAApplicationIT.java
@@ -57,10 +57,10 @@ public class JPAJAXRSCDIJTAApplicationIT extends AbstractIntegrationTest {
         assertThat(browser.getPageSource()).contains("*** On purpose failure during removal to test Rollback ***");
 
         browser.navigate().to("http://localhost:8080/rollbackMsg");
-        assertThat(browser.getPageSource().contains("5"));
+        assertThat(browser.getPageSource()).contains("5");
 
         browser.navigate().to("http://localhost:8080/commitMsg");
-        assertThat(browser.getPageSource().contains("0"));
+        assertThat(browser.getPageSource()).contains("0");
 
 
         testAll();
@@ -80,9 +80,9 @@ public class JPAJAXRSCDIJTAApplicationIT extends AbstractIntegrationTest {
         }
         assertThat(browser.getPageSource()).contains("*** On purpose failure during removal to test Rollback ***");
         browser.navigate().to("http://localhost:8080/rollbackMsg");
-        assertThat(browser.getPageSource().contains("0"));
+        assertThat(browser.getPageSource()).contains("0");
         browser.navigate().to("http://localhost:8080/commitMsg");
-        assertThat(browser.getPageSource().contains("3"));
+        assertThat(browser.getPageSource()).contains("3");
         browser.navigate().to("http://localhost:8080/all");
         assertThat(browser.getPageSource()).doesNotContain("{\"id\":1,\"name\":\"Penny\"}");
         assertThat(browser.getPageSource()).doesNotContain("{\"id\":2,\"name\":\"Sheldon\"}");

--- a/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-war/src/main/java/org/wildfly/swarm/examples/jpajaxrscdijta/EmployeeResource.java
+++ b/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-war/src/main/java/org/wildfly/swarm/examples/jpajaxrscdijta/EmployeeResource.java
@@ -51,6 +51,7 @@ public class EmployeeResource {
 
     @GET
     @Path("rollbackMsg")
+    @Produces("text/plain")
     public int getRollBackMsg() {
 
         return service.getRollbackMsg().size();
@@ -58,6 +59,7 @@ public class EmployeeResource {
 
     @GET
     @Path("commitMsg")
+    @Produces("text/plain")
     public int getCommitMsg() {
 
         return service.getCommitMsg().size();


### PR DESCRIPTION
Motivation
----------
Both the JPA+JAX-RS+CDI+JTA examples have the following exceptions
in the log:

    Could not find MessageBodyWriter for response object of type:
    java.lang.Integer of media type: text/html

yet the tests don't fail. This is because the FEST Assert API
is used wrongly and no assertions are actually made.

Modifications
-------------
Fix usage of the FEST Assert API so that asserts are actually made.
This itself makes the tests fail, but that is easy to fix: just
make the int-returning JAX-RS methods @Produces("text/plain"),
so that java.lang.Integer marshaller is found.

Result
------
More test coverage, less exceptions in the log, tests still pass.