### PR TITLE
Failure to build with clean Maven repo

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -4,6 +4,9 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+      url 'https://repository-projectodd.forge.cloudbees.com/snapshot'
+    }
   }
 
   dependencies {
@@ -28,6 +31,9 @@ swarm {
 repositories {
   mavenLocal()
   mavenCentral()
+  maven {
+    url 'https://repository-projectodd.forge.cloudbees.com/snapshot'
+  }
   maven {
     url 'https://maven.repository.redhat.com/nexus/content/repositories/thirdparty-releases/'
   }


### PR DESCRIPTION
In trying to figure out gradle errors, I found that a clean Maven repo would fail to build example without our SNAPSHOT repos in build