### PR TITLE
SWARM-714: Modify examples to not use jaxrs-cdi

### DIFF
--- a/camel/camel-jpa/pom.xml
+++ b/camel/camel-jpa/pom.xml
@@ -42,7 +42,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/config-options/cdi-injection/pom.xml
+++ b/config-options/cdi-injection/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/docker/docker-jaxrs-dockerfile/pom.xml
+++ b/docker/docker-jaxrs-dockerfile/pom.xml
@@ -30,7 +30,11 @@
   <dependencies>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
   </dependencies>
 

--- a/docker/docker-jaxrs/pom.xml
+++ b/docker/docker-jaxrs/pom.xml
@@ -24,7 +24,11 @@
   <dependencies>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/jaxrs/jaxrs-cdi-deltaspike/pom.xml
+++ b/jaxrs/jaxrs-cdi-deltaspike/pom.xml
@@ -80,10 +80,6 @@
       <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.deltaspike.core</groupId>
       <artifactId>deltaspike-core-api</artifactId>
     </dependency>

--- a/jaxrs/jaxrs-deltaspike-data/pom.xml
+++ b/jaxrs/jaxrs-deltaspike-data/pom.xml
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-shrinkwrap/pom.xml
+++ b/jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-shrinkwrap/pom.xml
@@ -53,7 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/jpa-jaxrs-cdi/jpa-jaxrs-cdi-shrinkwrap/pom.xml
+++ b/jpa-jaxrs-cdi/jpa-jaxrs-cdi-shrinkwrap/pom.xml
@@ -55,7 +55,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/messaging/messaging-mdb/pom.xml
+++ b/messaging/messaging-mdb/pom.xml
@@ -52,7 +52,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/security/jaas/basic/pom.xml
+++ b/security/jaas/basic/pom.xml
@@ -53,7 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>


### PR DESCRIPTION
Motivation
----------
As the jaxrs-cdi fraction is now implicitly brought in from jaxrs, our examples don't need to specify it directly.

Modifications
-------------
Remove jaxrs-cdi from examples, replacing with jaxrs and cdi where necessary

Result
------
No change to behavior of examples