### PR TITLE
Change Camel-Mail example to

### DIFF
--- a/camel/camel-mail/src/main/java/org/wildfly/swarm/examples/camel/mail/Main.java
+++ b/camel/camel-mail/src/main/java/org/wildfly/swarm/examples/camel/mail/Main.java
@@ -24,11 +24,10 @@ import org.wildfly.swarm.mail.MailFraction;
 
 public class Main {
     public static void main(String... args) throws Exception {
-        MailFraction fraction = MailFraction.defaultFraction();
         Swarm swarm = new Swarm();
 
         // Configure mock mail server SMTP session
-        swarm.fraction(fraction.smtpServer("greenmail", s -> s.host("localhost").port("10110").username("user1@localhost").password("password")));
+        swarm.fraction(new MailFraction().smtpServer("greenmail", s -> s.host("localhost").port(10110).username("user1@localhost").password("password")));
 
         // Deploy mock mail server
         swarm.start(true);


### PR DESCRIPTION
 - not create 2 SMTP servers.
 - use an integer instead of an integer-shaped string.