### PR TITLE
SWARM-855: add examples for integrating CDI with other Java EE technologies

### DIFF
--- a/camel/camel-mail/src/test/java/org/wildfly/swarm/examples/camel/mail/CamelMailIT.java
+++ b/camel/camel-mail/src/test/java/org/wildfly/swarm/examples/camel/mail/CamelMailIT.java
@@ -46,6 +46,6 @@ public class CamelMailIT extends AbstractIntegrationTest {
 			.returnContent()
 			.asString();
 
-		Assert.assertEquals(response, "Email sent to user1@localhost");
+		Assert.assertEquals("Email sent to user1@localhost", response);
 	}
 }

--- a/jaxrs/contract-based-testing/jaxrs-consumer/src/it/java/org/wildfly/swarm/it/jaxrs/ConsumerTest.java
+++ b/jaxrs/contract-based-testing/jaxrs-consumer/src/it/java/org/wildfly/swarm/it/jaxrs/ConsumerTest.java
@@ -49,6 +49,6 @@ public class ConsumerTest extends ConsumerPactTest {
 
     @Override
     protected void runTest(String url) throws IOException {
-        assertEquals(new ProviderClient(url).hello("FOOBAR"), "Howdy FOOBAR");
+        assertEquals("Howdy FOOBAR", new ProviderClient(url).hello("FOOBAR"));
     }
 }

--- a/jaxrs/jaxrs-cdi-beanvalidation/README.md
+++ b/jaxrs/jaxrs-cdi-beanvalidation/README.md
@@ -1,0 +1,53 @@
+# JAX-RS and CDI and Bean Validation .war Example
+
+This example takes a normal JAX-RS and CDI and Bean Validation build,
+and wraps it into a `-swarm` runnable jar.
+
+> Please raise any issues found with this example in our JIRA:
+> https://issues.jboss.org/browse/SWARM
+
+## Project `pom.xml`
+
+This project is a traditional JAX-RS and CDI and Bean Validation project,
+with maven packaging of `war` in the `pom.xml`
+
+    <packaging>war</packaging>
+
+The project adds a `<plugin>` to configure `wildfly-swarm-plugin` to
+create the runnable `.jar`.
+
+    <plugin>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-plugin</artifactId>
+      <version>${version.wildfly-swarm}</version>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+
+For this example we're letting the plugin auto detect what dependencies
+we might need for our application, so no WildFly Swarm specific dependencies
+need to be added.
+
+## Run
+
+You can run it many ways:
+
+* mvn package && java -jar ./target/example-jaxrs-cdi-beanvalidation-swarm.jar
+* mvn wildfly-swarm:run
+* In your IDE run the `org.wildfly.swarm.Swarm` class
+
+## Use
+
+Since WildFly Swarm apps tend to support one deployment per executable, it
+automatically adds a `jboss-web.xml` to the deployment if it doesn't already
+exist.  This is used to bind the deployment to the root of the web-server,
+instead of using the `.war`'s own name as the application context.
+
+To access the JAX-RS Resource:
+
+    http://localhost:8080/books

--- a/jaxrs/jaxrs-cdi-beanvalidation/pom.xml
+++ b/jaxrs/jaxrs-cdi-beanvalidation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
@@ -10,15 +10,15 @@
 
   <parent>
     <groupId>org.wildfly.swarm.examples</groupId>
-    <artifactId>examples-parent</artifactId>
+    <artifactId>examples-jaxrs</artifactId>
     <version>2016.12.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>example-jaxws</artifactId>
+  <artifactId>example-jaxrs-cdi-beanvalidation</artifactId>
 
-  <name>WildFly Swarm Examples: JAX-WS</name>
-  <description>WildFly Swarm Examples: JAX-WS</description>
+  <name>WildFly Swarm Examples: JAX-RS and CDI and Bean Validation</name>
+  <description>WildFly Swarm Examples: JAX-RS and CDI and Bean Validation</description>
 
   <packaging>war</packaging>
 
@@ -27,6 +27,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>2.6</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
@@ -59,6 +60,25 @@
       <artifactId>cdi-api</artifactId>
       <version>1.2</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <version>1.0.0.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <version>4.5.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jaxrs/jaxrs-cdi-beanvalidation/src/it/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/JAXRSApplicationIT.java
+++ b/jaxrs/jaxrs-cdi-beanvalidation/src/it/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/JAXRSApplicationIT.java
@@ -1,0 +1,50 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.beanvalidation;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.it.AbstractIntegrationTest;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+public class JAXRSApplicationIT extends AbstractIntegrationTest {
+
+    private String listBooks() throws IOException {
+        return Request.Get("http://localhost:8080/books").execute().returnContent().asString();
+    }
+
+    @Test
+    @InSequence(1)
+    public void empty() throws IOException {
+        assertThat(listBooks()).isEqualTo("[]");
+    }
+
+    @Test
+    @InSequence(2)
+    public void putInvalid() throws IOException {
+        HttpResponse response = Request.Put("http://localhost:8080/books?isbn=bad&title=Foo&author=Bar").execute()
+                .returnResponse();
+        assertThat(response.getStatusLine().getStatusCode()).isGreaterThanOrEqualTo(400);
+        String error = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        assertThat(error).contains("ISBN must be valid");
+        assertThat(listBooks()).isEqualTo("[]");
+    }
+
+    @Test
+    @InSequence(3)
+    public void putValid() throws IOException {
+        String response = Request.Put("http://localhost:8080/books?isbn=1234567890&title=Foo&author=Bar").execute()
+                .returnContent().asString();
+        assertThat(response).contains("\"title\":\"Foo\"");
+        assertThat(response).contains("\"author\":\"Bar\"");
+        assertThat(listBooks()).isNotEqualTo("[]").contains("\"isbn\":\"1234567890\"");
+    }
+}

--- a/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/Book.java
+++ b/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/Book.java
@@ -1,0 +1,41 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.beanvalidation;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+public class Book {
+    private long id;
+
+    @NotNull(message = "ISBN must be set")
+    @Pattern(regexp = "^\\d{9}[\\d|X]$", message = "ISBN must be valid") // the regexp here is very simplistic
+    private String isbn;
+
+    @NotNull(message = "Title must be set")
+    private String title;
+
+    @NotNull(message = "Author must be set")
+    private String author;
+
+    public Book(long id, String isbn, String title, String author) {
+        this.id = id;
+        this.isbn = isbn;
+        this.title = title;
+        this.author = author;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+}

--- a/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/BooksApplication.java
+++ b/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/BooksApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.beanvalidation;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class BooksApplication extends Application {
+}

--- a/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/BooksResource.java
+++ b/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/BooksResource.java
@@ -1,0 +1,31 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.beanvalidation;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/books")
+public class BooksResource {
+    @Inject
+    private BooksService books;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Book> getAll() {
+        return books.list();
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    public Book create(@QueryParam("isbn") String isbn,
+                       @QueryParam("title") String title,
+                       @QueryParam("author") String author) {
+        return books.create(isbn, title, author);
+    }
+}

--- a/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/BooksService.java
+++ b/jaxrs/jaxrs-cdi-beanvalidation/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/beanvalidation/BooksService.java
@@ -1,0 +1,36 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.beanvalidation;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@ApplicationScoped
+public class BooksService {
+    private AtomicLong idGenerator = new AtomicLong();
+
+    private List<Book> books = new CopyOnWriteArrayList<>();
+
+    public List<Book> list() {
+        return books;
+    }
+
+    @Valid
+    public Book create(
+            @NotNull(message = "ISBN must be set")
+            @Pattern(regexp = "^\\d{9}[\\d|X]$", message = "ISBN must be valid") // the regexp here is very simplistic
+            String isbn,
+            @NotNull(message = "Title must be set")
+            String title,
+            @NotNull(message = "Author must be set")
+            String author
+    ) {
+        Book book = new Book(idGenerator.incrementAndGet(), isbn, title, author);
+        books.add(book);
+        return book;
+    }
+}

--- a/jaxrs/jaxrs-cdi-ejb/README.md
+++ b/jaxrs/jaxrs-cdi-ejb/README.md
@@ -1,0 +1,53 @@
+# JAX-RS and CDI and EJB .war Example
+
+This example takes a normal JAX-RS and CDI and EJB build,
+and wraps it into a `-swarm` runnable jar.
+
+> Please raise any issues found with this example in our JIRA:
+> https://issues.jboss.org/browse/SWARM
+
+## Project `pom.xml`
+
+This project is a traditional JAX-RS and CDI and EJB project,
+with maven packaging of `war` in the `pom.xml`
+
+    <packaging>war</packaging>
+
+The project adds a `<plugin>` to configure `wildfly-swarm-plugin` to
+create the runnable `.jar`.
+
+    <plugin>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-plugin</artifactId>
+      <version>${version.wildfly-swarm}</version>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+
+For this example we're letting the plugin auto detect what dependencies
+we might need for our application, so no WildFly Swarm specific dependencies
+need to be added.
+
+## Run
+
+You can run it many ways:
+
+* mvn package && java -jar ./target/example-jaxrs-cdi-ejb-swarm.jar
+* mvn wildfly-swarm:run
+* In your IDE run the `org.wildfly.swarm.Swarm` class
+
+## Use
+
+Since WildFly Swarm apps tend to support one deployment per executable, it
+automatically adds a `jboss-web.xml` to the deployment if it doesn't already
+exist.  This is used to bind the deployment to the root of the web-server,
+instead of using the `.war`'s own name as the application context.
+
+To access the JAX-RS Resource:
+
+    http://localhost:8080/greetings

--- a/jaxrs/jaxrs-cdi-ejb/pom.xml
+++ b/jaxrs/jaxrs-cdi-ejb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
@@ -10,15 +10,15 @@
 
   <parent>
     <groupId>org.wildfly.swarm.examples</groupId>
-    <artifactId>examples-parent</artifactId>
+    <artifactId>examples-jaxrs</artifactId>
     <version>2016.12.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>example-jaxws</artifactId>
+  <artifactId>example-jaxrs-cdi-ejb</artifactId>
 
-  <name>WildFly Swarm Examples: JAX-WS</name>
-  <description>WildFly Swarm Examples: JAX-WS</description>
+  <name>WildFly Swarm Examples: JAX-RS and CDI and EJB</name>
+  <description>WildFly Swarm Examples: JAX-RS and CDI and EJB</description>
 
   <packaging>war</packaging>
 
@@ -27,6 +27,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
+        <version>2.6</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
@@ -59,6 +60,25 @@
       <artifactId>cdi-api</artifactId>
       <version>1.2</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <version>1.0.0.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+      <version>1.0.0.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <version>4.5.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jaxrs/jaxrs-cdi-ejb/src/it/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/JAXRSApplicationIT.java
+++ b/jaxrs/jaxrs-cdi-ejb/src/it/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/JAXRSApplicationIT.java
@@ -1,0 +1,19 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.ejb;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.it.AbstractIntegrationTest;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+public class JAXRSApplicationIT extends AbstractIntegrationTest {
+    @Test
+    public void empty() throws Exception {
+        String result = Request.Get("http://localhost:8080/greetings?name=Ladicek").execute().returnContent().asString();
+        assertThat(result).isEqualTo("Hello, Ladicek!");
+        assertThatLog(getStdOutLog()).hasLineContaining("Said: Hello, Ladicek!");
+    }
+}

--- a/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreeterBean.java
+++ b/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreeterBean.java
@@ -1,0 +1,10 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.ejb;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class GreeterBean {
+    public String hello(String name) {
+        return "Hello, " + name + "!";
+    }
+}

--- a/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreeterFacade.java
+++ b/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreeterFacade.java
@@ -1,0 +1,16 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.ejb;
+
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class GreeterFacade {
+    @EJB
+    private GreeterBean greeterBean;
+
+    public String hello(String name) {
+        String result = greeterBean.hello(name);
+        System.out.println("Said: " + result);
+        return result;
+    }
+}

--- a/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreetingsApplication.java
+++ b/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreetingsApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.ejb;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class GreetingsApplication extends Application {
+}

--- a/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreetingsResource.java
+++ b/jaxrs/jaxrs-cdi-ejb/src/main/java/org/wildfly/swarm/examples/jaxrs/cdi/ejb/GreetingsResource.java
@@ -1,0 +1,17 @@
+package org.wildfly.swarm.examples.jaxrs.cdi.ejb;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@Path("/greetings")
+public class GreetingsResource {
+    @Inject
+    private GreeterFacade greeterFacade;
+
+    @GET
+    public String get(@QueryParam("name") String name) {
+        return greeterFacade.hello(name);
+    }
+}

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -30,7 +30,9 @@
     <module>jaxrs-shrinkwrap-https</module>
     <module>jaxrs-shrinkwrap-ajp</module>
     <module>jaxrs-cdi</module>
+    <module>jaxrs-cdi-beanvalidation</module>
     <module>jaxrs-cdi-deltaspike</module>
+    <module>jaxrs-cdi-ejb</module>
     <module>contract-based-testing</module>
     <module>scala</module>
     <module>kotlin</module>

--- a/jaxws/src/it/java/org/wildfly/swarm/examples/jaxws/ClientIT.java
+++ b/jaxws/src/it/java/org/wildfly/swarm/examples/jaxws/ClientIT.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.wildfly.swarm.it.AbstractIntegrationTest;
 
 import static org.junit.Assert.assertEquals;
 
@@ -16,7 +17,7 @@ import static org.junit.Assert.assertEquals;
  * @author Yoshimasa Tanabe
  *
  */
-public class ClientIT {
+public class ClientIT extends AbstractIntegrationTest {
 
     /**
      * The path of the WSDL endpoint in relation to the deployed web application.
@@ -35,10 +36,11 @@ public class ClientIT {
     }
 
     @Test
-    public void testHello() {
+    public void testHello() throws Exception {
         // Get a response from the WebService
         final String response = client.sayHello();
         assertEquals("Hello World!", response);
+        assertThatLog(getStdOutLog()).hasLineContaining("Checked request context");
     }
 
     @Test

--- a/jaxws/src/it/java/org/wildfly/swarm/examples/jaxws/ClientIT.java
+++ b/jaxws/src/it/java/org/wildfly/swarm/examples/jaxws/ClientIT.java
@@ -38,14 +38,14 @@ public class ClientIT {
     public void testHello() {
         // Get a response from the WebService
         final String response = client.sayHello();
-        assertEquals(response, "Hello World!");
+        assertEquals("Hello World!", response);
     }
 
     @Test
     public void testHelloName() {
         // Get a response from the WebService
         final String response = client.sayHelloToName("John");
-        assertEquals(response, "Hello John!");
+        assertEquals("Hello John!", response);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class ClientIT {
 
         // Get a response from the WebService
         final String response = client.sayHelloToNames(names);
-        assertEquals(response, "Hello John, Mary & Mark!");
+        assertEquals("Hello John, Mary & Mark!", response);
     }
 
 }

--- a/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/HelloWorldServiceImpl.java
+++ b/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/HelloWorldServiceImpl.java
@@ -3,6 +3,7 @@ package org.wildfly.swarm.examples.jaxws;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.jws.WebService;
 
 /**
@@ -15,8 +16,12 @@ import javax.jws.WebService;
         targetNamespace = "http://wildfly-swarm.io/HelloWorld")
 public class HelloWorldServiceImpl implements HelloWorldService {
 
+    @Inject
+    private SimpleService simpleService;
+
     @Override
     public String sayHello() {
+        simpleService.checkRequestContext();
         return "Hello World!";
     }
 

--- a/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/SimpleService.java
+++ b/jaxws/src/main/java/org/wildfly/swarm/examples/jaxws/SimpleService.java
@@ -1,0 +1,17 @@
+package org.wildfly.swarm.examples.jaxws;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.RequestScoped;
+import javax.xml.ws.WebServiceContext;
+
+@RequestScoped
+public class SimpleService {
+    @Resource
+    private WebServiceContext webServiceContext;
+
+    public void checkRequestContext() {
+        if (webServiceContext != null) {
+            System.out.println("Checked request context");
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
CDI integrates with a bunch of other Java EE technologies.
WFLY-6941 specifically mentions:

- EJB
- JPA
- Bean Validation
- Web Services
- Transactions

Integration with JPA and transactions is already demonstrated
in examples `jpa-jaxrs-cdi/jpa-jaxrs-cdi-*`
and `jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta-*`.

There should be new examples to demonstrate integration with EJB
and Bean Validation. For Web Services, it should be enough to extend
the `jaxws` example a little, because the integration space
is fairly small.

Modifications
-------------
Added examples `jaxrs/jaxrs-cdi-beanvalidation` and `jaxrs/jaxrs-cdi-ejb`.
Modified the `jaxws` example a bit.

Result
------
The examples now demonstrate all CDI integrations. This means that they
also provide sufficient test coverage for the future, when Swarm wants
to use WFLY-6941.