### PR TITLE
SWARM-856: Cleanup main() examples

### DIFF
--- a/config-options/standalone.xml
+++ b/config-options/standalone.xml
@@ -129,7 +129,7 @@
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/CustomDS" pool-name="BSDS" enabled="true" use-java-context="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>
@@ -164,7 +164,7 @@
                     <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
                 </managed-scheduled-executor-services>
             </concurrent>
-            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/CustomDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
             <session-bean>

--- a/config-options/xml-configuration/README.adoc
+++ b/config-options/xml-configuration/README.adoc
@@ -7,14 +7,15 @@ This example demonstrates how to use XML configuration instead of the java confi
 == Referencing standalone.xml
 
 
-To reference a `standalone.xml` you need to bootstrap a `Container` with an URL pointing to your file:
+To reference a `standalone.xml` it can be part of your project, where it's picked up automatically,
+or you can pass it to WildFly Swarm with a `-c` parameter:
 
-[source,java]
+[source,xml]
 ----
-include::src/main/java/org/wildfly/swarm/examples/config/xml/XmlMain.java[lines=16..37]
+include::pom.xml[lines=39..45]
 ----
 
-See: link:src/main/java/org/wildfly/swarm/examples/config/xml/XmlMain.java#L16[XmlMain.java]
+See: link:pom.xml#L42[pom.xml]
 
 == Subsystem configuration in XML
 
@@ -23,7 +24,7 @@ These configuration will then be matched with the corresponding fractions automa
 
 [source,xml]
 ----
-include::src/main/resources/standalone.xml[lines=130..147]
+include::../standalone.xml[lines=130..147]
 ----
 
-See: link:src/main/resources/standalone.xml#L130[standalone.xml]
+See: link:../standalone.xml#L130[standalone.xml]

--- a/config-options/xml-configuration/pom.xml
+++ b/config-options/xml-configuration/pom.xml
@@ -24,8 +24,6 @@
 
   <properties>
     <version.h2>1.4.187</version.h2>
-    <version.postgresql>9.4.1207</version.postgresql>
-    <version.mysql>5.1.38</version.mysql>
   </properties>
 
   <build>
@@ -39,6 +37,12 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
+        <configuration>
+          <arguments>
+            <argument>-c</argument>
+            <argument>../standalone.xml</argument>
+          </arguments>
+        </configuration>
         <executions>
           <execution>
             <id>package</id>
@@ -66,6 +70,10 @@
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>datasources</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
     </dependency>
 
     <dependency>

--- a/config-options/xml-configuration/src/it/java/org/wildfly/swarm/examples/config/subsystem/XmlConfigIT.java
+++ b/config-options/xml-configuration/src/it/java/org/wildfly/swarm/examples/config/subsystem/XmlConfigIT.java
@@ -23,7 +23,7 @@ public class XmlConfigIT extends AbstractIntegrationTest {
     public void testIt() throws Exception {
         Log log = getStdOutLog();
 
-        assertThatLog( log ).hasLineContaining( "WFLYJCA0001: Bound data source [java:jboss/datasources/ExampleDS]" );
+        assertThatLog( log ).hasLineContaining( "WFLYJCA0001: Bound data source [java:jboss/datasources/CustomDS]" );
 
 
         browser.navigate().to("http://localhost:8080/");

--- a/config-options/xml-configuration/src/main/java/org/wildfly/swarm/examples/config/xml/MyResource.java
+++ b/config-options/xml-configuration/src/main/java/org/wildfly/swarm/examples/config/xml/MyResource.java
@@ -21,7 +21,7 @@ public class MyResource {
     @Produces("text/plain")
     public String get() throws NamingException, SQLException {
         Context ctx = new InitialContext();
-        DataSource ds = (DataSource) ctx.lookup("jboss/datasources/ExampleDS");
+        DataSource ds = (DataSource) ctx.lookup("jboss/datasources/CustomDS");
         Connection conn = ds.getConnection();
         try {
             return "Howdy using connection: " + conn;


### PR DESCRIPTION
Motivation
----------
Forgot to add details of setting standalone.xml on command line

Modifications
-------------
Move standalone.xml out of current directory so it isn't picked up automatically, and then set `-c` on plugin to pass it in.

Result
------
No product impact, fix example to be clearer