### PR TITLE
SWARM-997: Change SNAPSHOT repository to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
 
   <repositories>
     <repository>
-      <id>projectodd-snapshots</id>
-      <name>Project:odd Snapshots from CI</name>
-      <url>https://repository-projectodd.forge.cloudbees.com/snapshot</url>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -55,9 +55,9 @@
   </repositories>
   <pluginRepositories>
     <pluginRepository>
-      <id>projectodd-snapshots</id>
-      <name>Project:odd Snapshots from CI</name>
-      <url>https://repository-projectodd.forge.cloudbees.com/snapshot</url>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
Motivation
----------
Now SNAPSHOT artifacts is deployed on Maven Central,
examples should point it.

Modifications
-------------
Change the SNAPSHOT repo.

Result
------
No impact to product.