### PR TITLE
Using JBoss JDK base image

### DIFF
--- a/docker/docker-jaxrs-dockerfile/docker/Dockerfile
+++ b/docker/docker-jaxrs-dockerfile/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:jre-alpine
+FROM jboss/base-jdk:8
 
 ADD example-docker-jaxrs-dockerfile-swarm.jar /opt/wildfly-swarm.jar
 

--- a/docker/docker-jaxrs/pom.xml
+++ b/docker/docker-jaxrs/pom.xml
@@ -89,7 +89,7 @@
                     </ports>
                   </run>
                   <build>
-                    <from>java:openjdk-8-jdk</from>
+                    <from>jboss/base-jdk:8</from>
                     <ports>
                       <port>8080</port>
                     </ports>


### PR DESCRIPTION
Updating to use the JBoss OpenJDK-8 base image.

This image is used for other JBoss images, like vanilla wildfly:
https://github.com/jboss-dockerfiles/wildfly/blob/master/Dockerfile#L2

