### PR TITLE
SWARM-1042: Some examples use Container instead of Swarm

### DIFF
--- a/gradle-mail/src/main/java/org/wildfly/swarm/examples/mail/Main.java
+++ b/gradle-mail/src/main/java/org/wildfly/swarm/examples/mail/Main.java
@@ -1,7 +1,7 @@
 package org.wildfly.swarm.examples.mail;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.Swarm;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.mail.MailFraction;
 
@@ -11,7 +11,7 @@ import org.wildfly.swarm.mail.MailFraction;
 public class Main {
 
     public static void main(String[] args) throws Exception {
-        final Container container = new Container();
+        final Swarm container = new Swarm();
         final MailFraction fraction = new MailFraction();
         final String host = System.getProperty("smtp.host");
         final String port = System.getProperty("smtp.port");

--- a/jaxrs/scala/src/main/scala/org/wildfly/swarm/examples/scala/Main.scala
+++ b/jaxrs/scala/src/main/scala/org/wildfly/swarm/examples/scala/Main.scala
@@ -1,14 +1,14 @@
 package org.wildfly.swarm.examples.scala
 
 import org.jboss.shrinkwrap.api.ShrinkWrap
-import org.wildfly.swarm.container.Container
+import org.wildfly.swarm.Swarm
 import org.wildfly.swarm.jaxrs.JAXRSArchive
 
 // @author Helio Frota
 // @author Yoshimasa Tanabe
 object Main extends App {
 
-  val container = new Container()
+  val container = new Swarm()
 
   val deployment = ShrinkWrap.create(classOf[JAXRSArchive], "scala-wildfly-swarm.war")
   deployment.addClass(classOf[ScalaResource])

--- a/messaging/messaging-clustering/src/main/java/org/wildfly/swarm/examples/messaging/clustering/Main.java
+++ b/messaging/messaging-clustering/src/main/java/org/wildfly/swarm/examples/messaging/clustering/Main.java
@@ -2,7 +2,6 @@ package org.wildfly.swarm.examples.messaging.clustering;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.container.Container;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.messaging.MessagingFraction;
 import org.wildfly.swarm.msc.ServiceActivatorArchive;

--- a/resource-adapter/resource-adapter-deployment/src/main/java/org/wildfly/swarm/examples/rar/deployment/Main.java
+++ b/resource-adapter/resource-adapter-deployment/src/main/java/org/wildfly/swarm/examples/rar/deployment/Main.java
@@ -6,7 +6,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.container.Container;
 import org.wildfly.swarm.ejb.EJBFraction;
 import org.wildfly.swarm.resource.adapters.RARArchive;
 import org.wildfly.swarm.spi.api.JARArchive;

--- a/ribbon-secured/events/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/events/Main.java
+++ b/ribbon-secured/events/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/events/Main.java
@@ -1,7 +1,7 @@
 package org.wildfly.swarm.examples.netflix.ribbon.events;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.Swarm;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.jgroups.JGroupsFraction;
 import org.wildfly.swarm.keycloak.Secured;
@@ -13,7 +13,7 @@ import org.wildfly.swarm.netflix.ribbon.RibbonArchive;
 public class Main {
 
     public static void main(String[] args) throws Exception {
-        Container container = new Container();
+        Swarm container = new Swarm();
         JGroupsFraction fraction = new JGroupsFraction()
                 .defaultChannel("swarm-jgroups")
                 .stack("udp", (s) -> {

--- a/ribbon-secured/frontend/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/frontend/Main.java
+++ b/ribbon-secured/frontend/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/frontend/Main.java
@@ -1,7 +1,7 @@
 package org.wildfly.swarm.examples.netflix.ribbon.frontend;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.Swarm;
 import org.wildfly.swarm.jgroups.JGroupsFraction;
 import org.wildfly.swarm.undertow.WARArchive;
 
@@ -10,7 +10,7 @@ import org.wildfly.swarm.undertow.WARArchive;
  */
 public class Main {
     public static void main(String... args) throws Exception {
-        Container container = new Container();
+        Swarm container = new Swarm();
         JGroupsFraction fraction = new JGroupsFraction()
                 .defaultChannel( "swarm-jgroups")
                 .stack( "udp", (s)->{

--- a/ribbon-secured/time/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/time/Main.java
+++ b/ribbon-secured/time/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/time/Main.java
@@ -1,7 +1,7 @@
 package org.wildfly.swarm.examples.netflix.ribbon.time;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.Swarm;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.jgroups.JGroupsFraction;
 import org.wildfly.swarm.keycloak.Secured;
@@ -13,7 +13,7 @@ import org.wildfly.swarm.netflix.ribbon.RibbonArchive;
 public class Main {
 
     public static void main(String[] args) throws Exception {
-        Container container = new Container();
+        Swarm container = new Swarm();
         JGroupsFraction fraction = new JGroupsFraction()
                 .defaultChannel( "swarm-jgroups")
                 .stack( "udp", (s)->{


### PR DESCRIPTION
Motivation
----------
Some examples use the deprecated Container class. It should use Swarm instead

Modifications
-------------
The code was updated to use the correct class

Result
------
CI server should be happy