### PR TITLE
SWARM-1141: Pass user defined settings.xml to arquillian tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.19.1</version>
+          <configuration>
+            <systemPropertyVariables>
+              <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-war-plugin</artifactId>
@@ -177,6 +182,7 @@
           </includes>
           <systemPropertyVariables>
             <phantomjs.binary.version>2.1.1</phantomjs.binary.version>
+            <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
           </systemPropertyVariables>
         </configuration>
         <executions>


### PR DESCRIPTION
Motivation
----------
When building wildfly-swarm with an alternate settings.xml via mvn -s ..., arquillian tests still use the default one.

Modifications
-------------
See: https://github.com/wildfly-swarm/wildfly-swarm/pull/384

Result
------
See: https://github.com/wildfly-swarm/wildfly-swarm/pull/384