### PR TITLE
SWARM-1005 - Delineate between project and product bits

### DIFF
--- a/arjuna/pom.xml
+++ b/arjuna/pom.xml
@@ -23,7 +23,8 @@
   <packaging>pom</packaging>
 
   <modules>
-    <module>arjuna</module>
-    <module>stm</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -58,15 +58,9 @@
   </dependencyManagement>
 
   <modules>
-    <module>camel-activemq</module>
-    <module>camel-core</module>
-    <module>camel-cdi</module>
-    <module>camel-cxf-jaxrs</module>
-    <module>camel-cxf-jaxws</module>
-    <module>camel-jms</module>
-    <module>camel-jpa</module>
-    <module>camel-mail</module>
-    <module>camel-swagger</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 
 </project>

--- a/config-options/pom.xml
+++ b/config-options/pom.xml
@@ -24,7 +24,8 @@
 
 
   <modules>
-    <module>xml-configuration</module>
-    <module>cdi-injection</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/datasource/pom.xml
+++ b/datasource/pom.xml
@@ -24,7 +24,8 @@
 
 
   <modules>
-    <module>datasource-subsystem</module>
-    <module>datasource-war</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -23,7 +23,8 @@
   <packaging>pom</packaging>
 
   <modules>
-    <module>docker-jaxrs</module>
-    <module>docker-jaxrs-dockerfile</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -24,18 +24,8 @@
 
 
   <modules>
-    <module>jaxrs</module>
-    <module>jaxrs-https</module>
-    <module>jaxrs-ajp</module>
-    <module>jaxrs-cdi</module>
-    <module>jaxrs-cdi-deltaspike</module>
-    <module>contract-based-testing</module>
-    <module>scala</module>
-    <module>kotlin</module>
-    <module>swagger</module>
-    <module>health</module>	
-    <module>jaxrs-deltaspike-data</module>
-    <module>zipkin</module>
-    <module>opentracing-hawkular</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/jpa-jaxrs-cdi/pom.xml
+++ b/jpa-jaxrs-cdi/pom.xml
@@ -24,7 +24,8 @@
 
 
   <modules>
-    <module>jpa-jaxrs-cdi</module>
-    <module>jpa-jaxrs-cdi-jta</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -24,7 +24,8 @@
 
 
   <modules>
-    <module>jpa</module>
-    <module>jpa-eclipselink</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -24,8 +24,8 @@
 
 
   <modules>
-    <module>messaging-simple</module>
-    <module>messaging-mdb</module>
-    <module>messaging-clustering</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -252,50 +252,113 @@
     <module>base</module>
 
     <module>arjuna</module>
-    <module>camel</module>
+    <module>arjuna/arjuna</module>
+    <module>arjuna/stm</module>
     <module>config-options</module>
+    <module>config-options/cdi-injection</module>
+    <module>config-options/xml-configuration</module>
     <module>datasource</module>
-    <module>flyway</module>
+    <module>datasource/datasource-subsystem</module>
+    <module>datasource/datasource-war</module>
     <module>jaxrs</module>
-    <module>jaxws</module>
+    <module>jaxrs/jaxrs</module>
+    <module>jaxrs/jaxrs-https</module>
+    <module>jaxrs/jaxrs-ajp</module>
+    <module>jaxrs/jaxrs-cdi</module>
+    <module>jaxrs/jaxrs-cdi-deltaspike</module>
+    <module>jaxrs/contract-based-testing</module>
+    <module>jaxrs/health</module>
+    <module>jaxrs/jaxrs-deltaspike-data</module>
     <module>jpa</module>
+    <module>jpa/jpa</module>
     <module>jpa-jaxrs-cdi</module>
+    <module>jpa-jaxrs-cdi/jpa-jaxrs-cdi</module>
+    <module>jpa-jaxrs-cdi/jpa-jaxrs-cdi-jta</module>
     <module>jsf</module>
-    <module>management-console</module>
-    <module>messaging</module>
     <module>msc</module>
     <module>servlet</module>
+    <module>servlet/servlet</module>
+    <module>servlet/servlet-cdi</module>
     <module>static</module>
+    <module>static/static-shrinkwrap</module>
+    <module>static/static-war</module>
     <module>transactions</module>
-    <module>vaadin</module>
-    <module>vertx</module>
-    <module>ribbon</module>
-    <!-- <module>ribbon-secured</module> -->
-    <module>ribbon-consul</module>
-<!--
-    <module>gradle</module>
--->
-    <module>docker</module>
-    <module>spring</module>
-    <module>security</module>
-    <module>resource-adapter</module>
+    <module>transactions/transactions</module>
+
+<!-- <module>kitchensink-html5-mobile</module> -->
     <module>microprofile</module>
-    <module>swagger-webapp</module>
-<!--
-    <module>kitchensink-html5-mobile</module>
--->
-
-    <!-- extras -->
-<!--
-    <module>ribbon-secured</module>
--->
-    <module>logstash</module>
-
+    <module>security</module>
+    <module>security/jaas</module>
+    <module>security/keycloak</module>
+    <module>vaadin</module>
   </modules>
 
   <profiles>
     <profile>
+      <id>unsupported</id>
+      <activation>
+        <property>
+          <name>!swarm.product.build</name>
+        </property>
+      </activation>
+      <modules>
+        <module>camel</module>
+        <module>camel/camel-activemq</module>
+        <module>camel/camel-core</module>
+        <module>camel/camel-cdi</module>
+        <module>camel/camel-cxf-jaxrs</module>
+        <module>camel/camel-cxf-jaxws</module>
+        <module>camel/camel-jms</module>
+        <module>camel/camel-jpa</module>
+        <module>camel/camel-mail</module>
+        <module>camel/camel-swagger</module>
+        <module>jaxrs/kotlin</module>
+        <module>jaxrs/opentracing-hawkular</module>
+        <module>jaxrs/scala</module>
+        <module>jaxrs/swagger</module>
+        <module>jaxrs/zipkin</module>
+        <module>jaxws</module>
+        <module>jpa/jpa-eclipselink</module>
+        <module>management-console</module>
+        <module>messaging</module>
+        <module>messaging/messaging-simple</module>
+        <module>messaging/messaging-mdb</module>
+        <module>messaging/messaging-clustering</module>
+        <module>resource-adapter</module>
+        <module>resource-adapter/resource-adapter-deployment</module>
+
+        <!-- <module>gradle</module> -->
+
+        <module>flyway</module>
+        <module>logstash</module>
+        <module>ribbon</module> <!-- declares submodules due to wildfly-swarm:multistart -->
+        <module>ribbon-consul</module> <!-- declares submodules due to wildfly-swarm:multistart -->
+        <!-- <module>ribbon-secured</module> -->
+        <module>spring</module>
+        <module>spring/spring-data</module>
+        <module>swagger-webapp</module>
+        <module>vertx</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>bom-all</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+
+    <profile>
       <id>docker</id>
+      <modules>
+        <module>docker</module>
+        <module>docker/docker-jaxrs</module>
+        <module>docker/docker-jaxrs-dockerfile</module>
+      </modules>
     </profile>
     <profile>
       <id>uberjar</id>

--- a/resource-adapter/pom.xml
+++ b/resource-adapter/pom.xml
@@ -23,8 +23,8 @@
   <packaging>pom</packaging>
 
   <modules>
-    <module>resource-adapter-deployment</module>
-<!--     <module>resource-adapter-subsystem</module> -->
-<!--     <module>resource-adapter-war</module> -->
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -23,7 +23,8 @@
   <packaging>pom</packaging>
 
   <modules>
-    <module>jaas</module>
-    <module>keycloak</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -24,7 +24,8 @@
 
 
   <modules>
-    <module>servlet</module>
-    <module>servlet-cdi</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -23,6 +23,8 @@
   </properties>
 
   <modules>
-    <module>spring-data</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/static/pom.xml
+++ b/static/pom.xml
@@ -24,7 +24,8 @@
 
 
   <modules>
-    <module>static-war</module>
-    <module>static-shrinkwrap</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -24,6 +24,8 @@
 
 
   <modules>
-    <module>transactions</module>
+    <!-- DO NOT ADD MODULES HERE. THIS ACTS AS A PARENT POM ONLY.
+         ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
+         pom.xml OF THIS PROJECT. -->
   </modules>
 </project>


### PR DESCRIPTION
I realize this is probably a bit controversial and I'm prepared to be rejected, but I secretly hope I won't be :-)

Motivation
----------
The Swarm build has been split between project and product.
For running the examples with productized bits, it's easiest
to split the Swarm Examples build along the same lines.

Modifications
-------------
All Maven `<module>` declarations are moved to the root POM.
Modules for the examples that only use bits from the main bom
are always included unconditionally. Examples that require
bits from bom-all are moved to a profile that can be excluded
using a system property.

This is all very similar to the change done in Swarm itself.

Result
------
No change unless you include -Dswarm.product.build on your
CLI, at which point, fewer examples get built and tested.