### PR TITLE
SWARM-1279 - Fix RA deployment example

### DIFF
--- a/resource-adapter/resource-adapter-deployment/src/main/java/org/wildfly/swarm/examples/rar/deployment/FileIOBean.java
+++ b/resource-adapter/resource-adapter-deployment/src/main/java/org/wildfly/swarm/examples/rar/deployment/FileIOBean.java
@@ -2,11 +2,13 @@ package org.wildfly.swarm.examples.rar.deployment;
 
 import javax.annotation.Resource;
 import javax.annotation.Resource.AuthenticationType;
-import javax.ejb.Stateless;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
 
 import org.xadisk.connector.outbound.XADiskConnectionFactory;
 
-@Stateless
+@Singleton
+@Startup
 public class FileIOBean {
  
     @Resource(

--- a/resource-adapter/resource-adapter-deployment/src/main/java/org/wildfly/swarm/examples/rar/deployment/Main.java
+++ b/resource-adapter/resource-adapter-deployment/src/main/java/org/wildfly/swarm/examples/rar/deployment/Main.java
@@ -31,7 +31,7 @@ public class Main {
         swarm.deploy(rarArchive);
 
         final JARArchive appDeployment = ShrinkWrap.create(JARArchive.class);
-        appDeployment.merge(Swarm.artifact("net.java.xadisk:xadisk:jar:1.2.2"));
+        appDeployment.addModule("deployment.xadisk.rar");
         appDeployment.addClass(FileIOBean.class);
 
         // Deploy your app


### PR DESCRIPTION
Motivation:

Using an RA from a deployment failed when actually tested.

Changes:

Replace the duplication of classes with a dependency between the
app and the RA deployment.

Result:

It works and actually tests something.