### PR TITLE
Fixed Gradle example for Swarm version 2017.7.x

### DIFF
--- a/gradle-mail/build.gradle
+++ b/gradle-mail/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  version = '1.0.0.CR1-SNAPSHOT'
+  version = System.getProperty('swarmVersion') ?: '2017.6.1'
 
   repositories {
     mavenLocal()
@@ -7,8 +7,8 @@ buildscript {
   }
 
   dependencies {
-    classpath "io.spring.gradle:dependency-management-plugin:0.5.6.RELEASE"
-    classpath "org.wildfly.swarm:wildfly-swarm-plugin:$version"
+    classpath "io.spring.gradle:dependency-management-plugin:1.0.3.RELEASE"
+    classpath "org.wildfly.swarm:wildfly-swarm-gradle-plugin:$version"
   }
 }
 
@@ -19,11 +19,11 @@ apply plugin: 'application'
 
 mainClassName = 'org.wildfly.swarm.examples.mail.Main'
 
-swarm {
-  properties {
-    smtp.host = 'localhost'
-    smtp.port = '25'
-  }
+run {
+  systemProperties = [
+    'smtp.host': 'localhost',
+    'smtp.port': '25'
+  ]
 }
 
 repositories {

--- a/gradle-mail/src/main/java/org/wildfly/swarm/examples/mail/Main.java
+++ b/gradle-mail/src/main/java/org/wildfly/swarm/examples/mail/Main.java
@@ -14,7 +14,7 @@ public class Main {
         final Swarm container = new Swarm();
         final MailFraction fraction = new MailFraction();
         final String host = System.getProperty("smtp.host");
-        final String port = System.getProperty("smtp.port");
+        final int port = Integer.parseInt(System.getProperty("smtp.port"));
 
         System.out.println(String.format("Using smtp server at %s:%s", host, port));
 

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -7,8 +7,8 @@ buildscript {
   }
 
   dependencies {
-    classpath "io.spring.gradle:dependency-management-plugin:0.5.6.RELEASE"
-    classpath "org.wildfly.swarm:wildfly-swarm-plugin:$version"
+    classpath "io.spring.gradle:dependency-management-plugin:1.0.3.RELEASE"
+    classpath "org.wildfly.swarm:wildfly-swarm-gradle-plugin:$version"
   }
 }
 


### PR DESCRIPTION
Motivation
----------
When developing with gradle and I saw that the gradle example is very old. Updated it for the Swarm version 2017.7.
[SWARM-1021](https://issues.jboss.org/browse/SWARM-1021)

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
