### PR TITLE
Fix management console example

### DIFF
--- a/management-console/src/main/resources/project-defaults.yaml
+++ b/management-console/src/main/resources/project-defaults.yaml
@@ -8,6 +8,7 @@ swarm:
             bob:
               password: TACOS!
     http-interface-management-interface:
-      allowed-origin: http://localhost:8080
+      allowed-origins:
+       - http://localhost:8080
       security-realm: ManagementRealm
 


### PR DESCRIPTION
The console didn't work for me when importing the dependencies outlined in the `Readme` into my own project.

Based on the documentation at https://reference.wildfly-swarm.io/v/2017.10.0/fractions/management.html `allowed-origin` should be renamed to `allowed-origins` and converted to a list for it to work.