### PR TITLE
SWARM-842: Could not initialize Spring proxy

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -18,8 +18,8 @@
   <packaging>pom</packaging>
 
   <properties>
-    <version.spring-data-jpa>1.10.2.RELEASE</version.spring-data-jpa>
-    <version.spring>4.3.0.RELEASE</version.spring>
+    <version.spring-data-jpa>1.11.9.RELEASE</version.spring-data-jpa>
+    <version.spring>4.3.13.RELEASE</version.spring>
   </properties>
 
   <modules>

--- a/spring/spring-data/src/main/java/org/wildfly/swarm/examples/springdata/service/EmployeeServiceImpl.java
+++ b/spring/spring-data/src/main/java/org/wildfly/swarm/examples/springdata/service/EmployeeServiceImpl.java
@@ -54,6 +54,6 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     @Override
     public Employee findById(int id) {
-        return employeeRepository.getOne(id);
+        return employeeRepository.findOne(id);
     }
 }


### PR DESCRIPTION
Motivation
----------
Error when GETting specific resource.

Also update to latest Spring and Spring Data versions.

Modifications
-------------
Replace `getOne()` with `findOne()` and update versions of Spring framework.

Result
------
Fixes Spring Example errors