### PR TITLE
Use latest version, and less confusing version scheme

### DIFF
--- a/datasource/datasource-war/pom.xml
+++ b/datasource/datasource-war/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <version.h2>1.4.187</version.h2>
-    <version.postgresql>9.4.1207</version.postgresql>
+    <version.postgresql>42.2.2</version.postgresql>
     <version.mysql>5.1.38</version.mysql>
   </properties>
 


### PR DESCRIPTION
I am updating to the latest JDBC (4.2) driver for Postgres.

The version scheme for the drive has been changed, and the version number now thankfully no longer implies any JDBC or Psql server versions. See here:

https://jdbc.postgresql.org/documentation/faq.html#versioning