### PR TITLE
SWARM-1983: update default fraction configuration to WildFly 11

### DIFF
--- a/camel/camel-jms/src/main/resources/project-defaults.yml
+++ b/camel/camel-jms/src/main/resources/project-defaults.yml
@@ -1,0 +1,6 @@
+swarm:
+  messaging-activemq:
+    servers:
+      default:
+        jms-queues:
+          TestQueue:


### PR DESCRIPTION
Motivation
----------
Recently, default configuration of the `messaging` fraction changed
to closely match default configuration of the `messaging-activemq`
subsystem in WildFly.

As part of that change, we now configure the `address-setting`,
with a couple of unrelated options. However, the mere fact of
adding a configuration of `address-setting` causes the subsystem
to override default behavior of ActiveMQ Artemis in one important
aspect: automatic creation of queues and topics.

ActiveMQ Artemis, by default, enables queues and topics to be
automatically created on demand and automatically dropped
when empty and without consumers. The `messaging-activemq`
subsystem in WildFly overrides this default, to match behavior
of the legacy `messaging` subsystem based on HornetQ.
This override happens in the handler for `address-setting`.

To sum up, we previously unknowingly allowed automatic creation
of queues and topics, and now we don't. I believe that's
the correct thing to do.

Modifications
-------------
Explicitly create the `TestQueue` queue, on which the `camel-jms`
example relies.

Result
------
The `camel-jms` example works fine again.